### PR TITLE
Italian dictionary: fix typo in word 'essere'

### DIFF
--- a/data/it.words
+++ b/data/it.words
@@ -285,7 +285,7 @@ di
 distruttivo
 per
 l
-esssere
+essere
 umano
 affermava
 che


### PR DESCRIPTION
Found a small typo in the italian word 'essere' ('esssere' was there instead).